### PR TITLE
fix: ignoreNodeModules option should accept false

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ function addHook(hook, opts) {
 
   opts = opts || {};
   matcher = opts.matcher || null;
-  ignoreNodeModules = opts.ignoreNodeModules || true;
+  ignoreNodeModules = opts.ignoreNodeModules !== false;
   exts = opts.extensions || opts.exts || opts.extension || opts.ext || ['.js'];
   if (!Array.isArray(exts)) exts = [exts];
 


### PR DESCRIPTION
With the current formulation, the value of `ignoreNodeModules` will always be `true`.

```sh
> ({ignoreNodeModules: false}).ignoreNodeModules || true
true
```

Using the `!== false` form, it allows proper defaulting to `true` when the argument is absent, as well as allowing `false` when specified as such.

```sh
> ({ignoreNodeModules: false}).ignoreNodeModules !== false
false
> ({ignoreNodeModules: true}).ignoreNodeModules !== false
true
> ({}).ignoreNodeModules !== false
true
```

(`matcher = opts.matcher || null` is also redundant, as `matcher = opts.matcher` when `opts === {}` evaluates to `matcher === undefined`, but I figured a targeted change was more proper)