### PR TITLE
Allow returning empty string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ function addHook(hook, opts) {
             // The compile function is also anyway created new when the loader is called a second time.
             mod._compile = compile;
             newCode = hook(code, filename);
-            if (!newCode || typeof newCode !== 'string') {
+            if (typeof newCode !== 'string') {
               throw new Error(HOOK_RETURNED_NOTHING_ERROR_MESSAGE);
             }
 


### PR DESCRIPTION
And empty string is a total valid return value from compile if for example the input is also empty
or if code gets stripped and nothing is left afterwards.

@ariporad Could you also add @hzoo or me to this repo, so that we can make quick fixes when we start rolling out babel-register with pirates?